### PR TITLE
Update version of spock to 0.7-groovy-2.0. @TestCategory works fluent with current spock version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,9 +8,9 @@ repositories {
 }
 
 dependencies {
-    compile "junit:junit:4.8.2"
+    compile "junit:junit:4.10"
     compile "commons-lang:commons-lang:2.6"
-    compile "org.spockframework:spock-core:0.5-groovy-1.7"
-    groovy "org.codehaus.groovy:groovy-all:1.7.4"
+    compile "org.spockframework:spock-core:0.7-groovy-2.0"
+    groovy "org.codehaus.groovy:groovy-all:2.0.5"
     testCompile "org.mockito:mockito-all:1.8.5"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,19 @@
     </parent>
     <groupId>no.kodemaker</groupId>
     <artifactId>categorize-test</artifactId>
-    <version>2.1-SNAPSHOT</version>
+    <version>3.0-SNAPSHOT</version>
     <name>Categorize-test</name>
     <description>Library which gives every project using junit &gt; 4.8 an opportunity to categorize there tests</description>
     <packaging>jar</packaging>
 
     <properties>
-        <groovy.version>1.8.5</groovy.version>
+        <jdk.version>1.7</jdk.version>
+
+        <groovy.version>2.0.5</groovy.version>
+        <gmaven.version>1.5</gmaven.version>
+        <spock.version>0.7-groovy-2.0</spock.version>
+        <junit.version>4.10</junit.version>
+
     </properties>
 
     <dependencies>
@@ -21,7 +27,7 @@
             <groupId>junit</groupId>
             <artifactId>junit-dep</artifactId>
             <scope>compile</scope>
-            <version>4.10</version>
+            <version>${junit.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
@@ -31,7 +37,7 @@
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
-            <version>0.6-groovy-1.8-SNAPSHOT</version>
+            <version>${spock.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.codehaus.groovy</groupId>
@@ -53,16 +59,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.5.1</version>
                 <inherited>true</inherited>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.11</version>
+                <version>2.12.4</version>
                 <configuration>
                     <parallel>classes</parallel>
                     <threadCount>1</threadCount>
@@ -78,9 +85,9 @@
             <plugin>
                 <groupId>org.codehaus.gmaven</groupId>
                 <artifactId>gmaven-plugin</artifactId>
-                <version>1.3</version>
+                <version>${gmaven.version}</version>
                 <configuration>
-                    <providerSelection>1.7</providerSelection>
+                    <providerSelection>2.0</providerSelection>
                     <source />
                 </configuration>
                 <executions>
@@ -94,8 +101,8 @@
                 <dependencies>
                     <dependency>
                         <groupId>org.codehaus.gmaven.runtime</groupId>
-                        <artifactId>gmaven-runtime-1.7</artifactId>
-                        <version>1.3</version>
+                        <artifactId>gmaven-runtime-2.0</artifactId>
+                        <version>${gmaven.version}</version>
                         <exclusions>
                             <exclusion>
                                 <groupId>org.codehaus.groovy</groupId>

--- a/src/test/groovy/no/kodemaker/categorize/junit/CategoryAwareSpockSpec.groovy
+++ b/src/test/groovy/no/kodemaker/categorize/junit/CategoryAwareSpockSpec.groovy
@@ -6,7 +6,6 @@ import no.kodemaker.categorize.spock.CategorizableSpecification
 import spock.lang.Ignore
 
 
-@Ignore
 class CategoryAwareSpockSpec extends CategorizableSpecification {
 
     def setupSpec(){


### PR DESCRIPTION
Update version of spock to 0.7-groovy-2.0 , as of this version as improved Junit compatibility
-  org.junit.internal.AssumptionViolatedException are now recognized by spock (as of Junit @Rule)
-  Bumping groovy and gmaven versions accordingly
  -- See http://docs.spockframework.org/en/spock-0.7-groovy-2.0/new_and_noteworthy.html
  Java 7 runtime is required
  Project update to 3.0-SNAPSHOT (not backward compatible)
